### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/khal/aux.py
+++ b/khal/aux.py
@@ -94,7 +94,7 @@ def weekdaypstr(dayname):
         return 5
     if dayname in ['sunday', 'sun']:
         return 6
-    raise ValueError('invalid weekday name `%s`' % dayname)
+    raise ValueError('invalid weekday name `{0!s}`'.format(dayname))
 
 
 def calc_day(dayname):

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -201,7 +201,7 @@ class _NoConfig(object):
 def prepare_context(ctx, config):
     assert ctx.obj is None
 
-    logger.debug('khal %s' % __version__)
+    logger.debug('khal {0!s}'.format(__version__))
     try:
         conf = get_config(config)
     except NoConfigFile:

--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -78,7 +78,7 @@ class Event(object):
         else:
             self._end = end
         if kwargs:
-            raise TypeError('%s are invalid keyword arguments to this function' % kwargs.keys())
+            raise TypeError('{0!s} are invalid keyword arguments to this function'.format(kwargs.keys()))
 
     @classmethod
     def _get_type_from_vDDD(cls, start):

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -106,7 +106,7 @@ class U_Event(urwid.Text):
                 self.eventcolumn.pane.window.backtrack()
                 self.eventcolumn.pane.window.alert(
                     ('light red',
-                     'Failed to save event: %s' % e))
+                     'Failed to save event: {0!s}'.format(e)))
                 return
 
             self.eventcolumn.pane.window.backtrack()
@@ -585,7 +585,7 @@ class EventEditor(urwid.WidgetWrap):
                 self.pane.window.backtrack()
                 self.pane.window.alert(
                     ('light red',
-                     'Failed to save event: %s' % e))
+                     'Failed to save event: {0!s}'.format(e)))
                 return
 
             self.pane.window.backtrack()
@@ -665,7 +665,7 @@ class ExportDialog(urwid.WidgetWrap):
         lines.append(urwid.Text('Export event as ICS file'))
         lines.append(urwid.Text(''))
         export_location = Edit(caption='Location: ',
-                               edit_text="~/%s.ics" % event.summary.strip())
+                               edit_text="~/{0!s}.ics".format(event.summary.strip()))
         lines.append(export_location)
         lines.append(urwid.Divider(' '))
         lines.append(

--- a/khal/ui/calendarwidget.py
+++ b/khal/ui/calendarwidget.py
@@ -150,7 +150,7 @@ class DateCColumns(urwid.Columns):
             if day[0].date == a_date:
                 self._set_focus_position(num)
                 return None
-        raise ValueError('%s not found in this week' % a_date)
+        raise ValueError('{0!s} not found in this week'.format(a_date))
 
     def get_date_column(self, a_date):
         """return the column `a_date` is in, raises ValueError if `a_date`
@@ -159,7 +159,7 @@ class DateCColumns(urwid.Columns):
         for num, day in enumerate(self.contents[1:8], 1):
             if day[0].date == a_date:
                 return num
-        raise ValueError('%s not found in this week' % a_date)
+        raise ValueError('{0!s} not found in this week'.format(a_date))
 
     focus_position = property(
         urwid.Columns._get_focus_position,


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:khal?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:khal?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
